### PR TITLE
1.0.1 / 2023-09-18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # gh-merge-upstream
 
+## 1.0.1 / 2023-09-18
+- Add installation instruction to [`README`](./README)
+- `usage()`: use variable instead of hardcoded tool name
+- `halt-error()`: print diagnostic only if there are still items in `$@`
+- Add `-h | --help | --usage` into cmdline argument parser loop
+- Workaround use of `insteadOf` GIT CLI config option by replacing `git remote get-url "${remote}"`
+  with `git config --get remote."${remote}".url`
+
 ## 1.0.0 / 2023-09-16
 
 Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # gh-merge-upstream
 
 ## 1.0.1 / 2023-09-18
-- Add installation instruction to [`README`](./README)
+- Add installation instruction to [`README`](./README.md)
 - `usage()`: use variable instead of hardcoded tool name
 - `halt-error()`: print diagnostic only if there are still items in `$@`
 - Add `-h | --help | --usage` into cmdline argument parser loop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # gh-merge-upstream
 
 ## 1.0.1 / 2023-09-18
+
 - Add installation instruction to [`README`](./README.md)
+- Add `Contributors` section to [`README`](./README.md)
 - `usage()`: use variable instead of hardcoded tool name
-- `halt-error()`: print diagnostic only if there are still items in `$@`
+- `halt-error()`: print meaningful message content when no positional parameters (`$@`) were passed
 - Add `-h | --help | --usage` into cmdline argument parser loop
-- Workaround use of `insteadOf` GIT CLI config option by replacing `git remote get-url "${remote}"`
-  with `git config --get remote."${remote}".url`
+- Workaround use of `url.<base>.insteadOf` mapping by querying local config
 
 ## 1.0.0 / 2023-09-16
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ gh api repos/TARGET_REPO/merge-upstream -F branch=UPSTREAM_BRANCH
 If there are insufficient permissions for your token, `gh api` will advise the
 correct action to take.
 
+## Installation
+
+```sh
+gh extension install halostatue/gh-merge-upstream
+```
+
 ## Usage
 
 `gh-merge-upstream` works best and easiest if you are in a local clone of the

--- a/README.md
+++ b/README.md
@@ -51,3 +51,8 @@ The name of the remote (`upstream`), shorthand repository name (`owner/repo`),
 or repository URL (`https://github.com/owner/repo`) for the parent repository
 and used only when `--branch` is not provided. Defaults `upstream` of the
 current git repo.
+
+## Contributors
+
+- Austin Ziegler (@halostatue) created gh-merge-upstream.
+- George L. Yermulnik (@yermulnik)

--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ current git repo.
 
 ## Contributors
 
-- Austin Ziegler (@halostatue) created gh-merge-upstream.
-- George L. Yermulnik (@yermulnik)
+- Austin Ziegler ([@halostatue](https://github.com/halostatue)) created gh-merge-upstream.
+- George L. Yermulnik ([@yermulnik](https://github.com/yermulnik))

--- a/gh-merge-upstream
+++ b/gh-merge-upstream
@@ -64,7 +64,8 @@ halt-error() {
     shift
   fi
 
-  [[ $@ ]] && echo >&2 "${bn0}: $*"
+  [[ $@ ]] || set -- error
+  echo >&2 "${bn0}: $*"
   "${call_usage}" && usage >&2
   exit 1
 }
@@ -171,7 +172,8 @@ while (($#)); do
     shift
     ;;
   -h | --help | --usage)
-    halt-error --usage
+    usage
+    exit 0
     ;;
   *)
     args+=("$1")
@@ -204,8 +206,7 @@ if [[ "${in_git}" ]]; then
   readarray -t remotes < <(git remote)
 
   for remote in "${remotes[@]}"; do
-    #remote_urls["${remote}"]="$(git remote get-url "${remote}")"
-    # workaround "insteadOf" by querying local config
+    # workaround "url.<base>.insteadOf" mapping by querying local config
     remote_urls["${remote}"]="$(git config --get remote."${remote}".url)"
   done
 fi

--- a/gh-merge-upstream
+++ b/gh-merge-upstream
@@ -30,7 +30,7 @@ fi
 
 usage() {
   cat <<USAGE
-Usage: gh-merge-upstream [options] [TARGET_REPO]
+Usage: ${bn0} [options] [TARGET_REPO]
 
 Uses the GitHub API to update your fork of a repository to the current
 state of the parent repository.
@@ -64,7 +64,7 @@ halt-error() {
     shift
   fi
 
-  echo >&2 "${bn0}: $*"
+  [[ $@ ]] && echo >&2 "${bn0}: $*"
   "${call_usage}" && usage >&2
   exit 1
 }
@@ -170,6 +170,9 @@ while (($#)); do
     branch="$2"
     shift
     ;;
+  -h | --help | --usage)
+    halt-error --usage
+    ;;
   *)
     args+=("$1")
     ;;
@@ -201,7 +204,9 @@ if [[ "${in_git}" ]]; then
   readarray -t remotes < <(git remote)
 
   for remote in "${remotes[@]}"; do
-    remote_urls["${remote}"]="$(git remote get-url "${remote}")"
+    #remote_urls["${remote}"]="$(git remote get-url "${remote}")"
+    # workaround "insteadOf" by querying local config
+    remote_urls["${remote}"]="$(git config --get remote."${remote}".url)"
   done
 fi
 


### PR DESCRIPTION
- Add installation instruction to [`README`](./README)
- `usage()`: use variable instead of hardcoded tool name
- `halt-error()`: print diagnostic only if there are still items in `$@`
- Add `-h | --help | --usage` into cmdline argument parser loop
- Workaround use of `insteadOf` GIT CLI config option by replacing `git remote get-url "${remote}"`
  with `git config --get remote."${remote}".url`